### PR TITLE
disable gcc-14 and gcc-arm runners. enable gcc-15 and reduce scheduled times

### DIFF
--- a/.github/workflows/csmith-gcc-14.yaml
+++ b/.github/workflows/csmith-gcc-14.yaml
@@ -3,9 +3,9 @@ name: csmith-gcc-14
 # Build a random riscv config
 
 on:
-  schedule:
-    # Run every hour every day
-    - cron: 0 * * * *
+  # schedule:
+  #   # Run every hour every day
+  #   - cron: 0 0 * * *
   workflow_dispatch:
     branches:
       - main

--- a/.github/workflows/csmith-gcc-15.yaml
+++ b/.github/workflows/csmith-gcc-15.yaml
@@ -4,8 +4,8 @@ name: csmith-gcc-15
 
 on:
   schedule:
-    # Run every hour every day
-    - cron: 0 * * * *
+    # Run twice every day
+    - cron: 0 0,12 * * *
   workflow_dispatch:
     branches:
       - main

--- a/.github/workflows/csmith-gcc-arm.yaml
+++ b/.github/workflows/csmith-gcc-arm.yaml
@@ -5,9 +5,9 @@ name: csmith-gcc-arm
 # another avenue to hit middle-end bugs.
 
 on:
-  schedule:
-    # Run every day
-    - cron: 0 0,12 * * *
+  # schedule:
+  #   # Run every day
+  #   - cron: 0 0 * * *
   workflow_dispatch:
     branches:
       - main

--- a/.github/workflows/csmith-gcc.yaml
+++ b/.github/workflows/csmith-gcc.yaml
@@ -4,8 +4,8 @@ name: csmith-gcc
 
 on:
   schedule:
-    # Run every hour every day
-    - cron: 0 * * * *
+    # Run twice every day
+    - cron: 0 0,12 * * *
   workflow_dispatch:
     branches:
       - main

--- a/.github/workflows/csmith-llvm.yaml
+++ b/.github/workflows/csmith-llvm.yaml
@@ -4,8 +4,8 @@ name: csmith-llvm
 
 on:
   schedule:
-    # Run every hour every day
-    - cron: 0 * * * *
+    # Run twice every day
+    - cron: 0 0,12 * * *
   workflow_dispatch:
     branches:
       - main


### PR DESCRIPTION
we forgot to reduce the frequency of runners since christmas. Make scheduled runners run twice a day instead of 24 times a day